### PR TITLE
 Refactor the connection handling loop to be more readable 

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -5,15 +5,14 @@ import (
 	"fmt"
 
 	"database/sql"
-	"github.com/secmask/go-redisproto"
 )
 
 type redisCommand interface {
-	Execute(command *redisproto.Command, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error)
+	Execute(command *redisRequest, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error)
 }
 
 type unrecognisedCommand struct{}
 
-func (cmd *unrecognisedCommand) Execute(command *redisproto.Command, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
+func (cmd *unrecognisedCommand) Execute(command *redisRequest, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
 	return nil, errors.New(fmt.Sprintf("Command %s not recognised", command.Get(0)))
 }

--- a/cmd_connection.go
+++ b/cmd_connection.go
@@ -2,19 +2,18 @@ package pgredis
 
 import (
 	"database/sql"
-	"github.com/secmask/go-redisproto"
 )
 
 type echoCommand struct{}
 
-func (cmd *echoCommand) Execute(command *redisproto.Command, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
+func (cmd *echoCommand) Execute(command *redisRequest, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
 	arg := command.Get(1)
 	return newPgRedisString(string(arg)), nil
 }
 
 type pingCommand struct{}
 
-func (cmd *pingCommand) Execute(command *redisproto.Command, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
+func (cmd *pingCommand) Execute(command *redisRequest, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
 	arg := command.Get(1)
 	if len(arg) == 0 {
 		return newPgRedisString("PONG"), nil
@@ -25,12 +24,12 @@ func (cmd *pingCommand) Execute(command *redisproto.Command, redis *PgRedis, tx 
 
 type quitCommand struct{}
 
-func (cmd *quitCommand) Execute(command *redisproto.Command, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
+func (cmd *quitCommand) Execute(command *redisRequest, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
 	return newPgRedisString("OK"), nil
 }
 
 type selectCommand struct{}
 
-func (cmd *selectCommand) Execute(command *redisproto.Command, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
+func (cmd *selectCommand) Execute(command *redisRequest, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
 	return newPgRedisString("OK"), nil
 }

--- a/cmd_hashes.go
+++ b/cmd_hashes.go
@@ -2,13 +2,12 @@ package pgredis
 
 import (
 	"database/sql"
-	"github.com/secmask/go-redisproto"
 	"log"
 )
 
 type hgetCommand struct{}
 
-func (cmd *hgetCommand) Execute(command *redisproto.Command, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
+func (cmd *hgetCommand) Execute(command *redisRequest, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
 	key := command.Get(1)
 	field := command.Get(2)
 	success, value, err := redis.hashes.Get(tx, key, field)
@@ -25,7 +24,7 @@ func (cmd *hgetCommand) Execute(command *redisproto.Command, redis *PgRedis, tx 
 
 type hmgetCommand struct{}
 
-func (cmd *hmgetCommand) Execute(command *redisproto.Command, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
+func (cmd *hmgetCommand) Execute(command *redisRequest, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
 	key := command.Get(1)
 	values := make([]pgRedisValue, command.ArgCount()-2)
 	for i := 2; i < command.ArgCount(); i++ {
@@ -42,7 +41,7 @@ func (cmd *hmgetCommand) Execute(command *redisproto.Command, redis *PgRedis, tx
 
 type hgetallCommand struct{}
 
-func (cmd *hgetallCommand) Execute(command *redisproto.Command, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
+func (cmd *hgetallCommand) Execute(command *redisRequest, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
 	key := command.Get(1)
 	fields_and_values, err := redis.hashes.GetAll(tx, key)
 	if err != nil {
@@ -53,7 +52,7 @@ func (cmd *hgetallCommand) Execute(command *redisproto.Command, redis *PgRedis, 
 
 type hmsetCommand struct{}
 
-func (cmd *hmsetCommand) Execute(command *redisproto.Command, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
+func (cmd *hmsetCommand) Execute(command *redisRequest, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
 	key := string(command.Get(1))
 	items := make(map[string]string)
 
@@ -69,7 +68,7 @@ func (cmd *hmsetCommand) Execute(command *redisproto.Command, redis *PgRedis, tx
 
 type hsetCommand struct{}
 
-func (cmd *hsetCommand) Execute(command *redisproto.Command, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
+func (cmd *hsetCommand) Execute(command *redisRequest, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
 	key := command.Get(1)
 	field := command.Get(2)
 	value := command.Get(3)

--- a/cmd_keys.go
+++ b/cmd_keys.go
@@ -4,13 +4,11 @@ import (
 	"database/sql"
 	"log"
 	"strconv"
-
-	"github.com/secmask/go-redisproto"
 )
 
 type delCommand struct{}
 
-func (cmd *delCommand) Execute(command *redisproto.Command, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
+func (cmd *delCommand) Execute(command *redisRequest, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
 	result := int64(0)
 	for i := 1; i < command.ArgCount(); i++ {
 		// TODO calling Delete in a loop like this returns the correct result, but is super
@@ -28,7 +26,7 @@ func (cmd *delCommand) Execute(command *redisproto.Command, redis *PgRedis, tx *
 
 type existsCommand struct{}
 
-func (cmd *existsCommand) Execute(command *redisproto.Command, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
+func (cmd *existsCommand) Execute(command *redisRequest, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
 	result := int64(0)
 	for i := 1; i < command.ArgCount(); i++ {
 		success, err := redis.keys.Exist(tx, command.Get(i))
@@ -44,7 +42,7 @@ func (cmd *existsCommand) Execute(command *redisproto.Command, redis *PgRedis, t
 
 type expireCommand struct{}
 
-func (cmd *expireCommand) Execute(command *redisproto.Command, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
+func (cmd *expireCommand) Execute(command *redisRequest, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
 	key := command.Get(1)
 	seconds, _ := strconv.Atoi(string(command.Get(2)))
 
@@ -62,7 +60,7 @@ func (cmd *expireCommand) Execute(command *redisproto.Command, redis *PgRedis, t
 
 type pttlCommand struct{}
 
-func (cmd *pttlCommand) Execute(command *redisproto.Command, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
+func (cmd *pttlCommand) Execute(command *redisRequest, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
 	key := command.Get(1)
 	// this should probably use KeyRepository and not be string specific
 	keyExists, millis, err := redis.keys.TTLInMillis(tx, key)
@@ -80,7 +78,7 @@ func (cmd *pttlCommand) Execute(command *redisproto.Command, redis *PgRedis, tx 
 
 type ttlCommand struct{}
 
-func (cmd *ttlCommand) Execute(command *redisproto.Command, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
+func (cmd *ttlCommand) Execute(command *redisRequest, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
 	key := command.Get(1)
 	// this should probably use KeyRepository and not be string specific
 	success, resp, err := redis.strings.Get(tx, key)
@@ -98,7 +96,7 @@ func (cmd *ttlCommand) Execute(command *redisproto.Command, redis *PgRedis, tx *
 
 type typeCommand struct{}
 
-func (cmd *typeCommand) Execute(command *redisproto.Command, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
+func (cmd *typeCommand) Execute(command *redisRequest, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
 	key := command.Get(1)
 	result, err := redis.keys.Type(tx, key)
 	if err != nil {

--- a/cmd_lists.go
+++ b/cmd_lists.go
@@ -3,7 +3,6 @@ package pgredis
 import (
 	"database/sql"
 	"fmt"
-	"github.com/secmask/go-redisproto"
 	"strconv"
 	"time"
 )
@@ -12,7 +11,7 @@ type brpopCommand struct{}
 
 // TODO this sleeping approach might work, but it's lame. It'd be neat to use psql NOTIFY
 // to be informed when a list is ready to rpop
-func (cmd *brpopCommand) Execute(command *redisproto.Command, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
+func (cmd *brpopCommand) Execute(command *redisRequest, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
 	listCount := command.ArgCount() - 2
 	listKeys := []string{}
 	for i := 1; i <= listCount; i++ {
@@ -41,7 +40,7 @@ func (cmd *brpopCommand) Execute(command *redisproto.Command, redis *PgRedis, tx
 
 type llenCommand struct{}
 
-func (cmd *llenCommand) Execute(command *redisproto.Command, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
+func (cmd *llenCommand) Execute(command *redisRequest, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
 	key := command.Get(1)
 	length, err := redis.lists.Length(tx, key)
 	if err != nil {
@@ -52,7 +51,7 @@ func (cmd *llenCommand) Execute(command *redisproto.Command, redis *PgRedis, tx 
 
 type lpopCommand struct{}
 
-func (cmd *lpopCommand) Execute(command *redisproto.Command, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
+func (cmd *lpopCommand) Execute(command *redisRequest, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
 	key := command.Get(1)
 	success, value, err := redis.lists.LeftPop(tx, key)
 	if err != nil {
@@ -67,7 +66,7 @@ func (cmd *lpopCommand) Execute(command *redisproto.Command, redis *PgRedis, tx 
 
 type lpushCommand struct{}
 
-func (cmd *lpushCommand) Execute(command *redisproto.Command, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
+func (cmd *lpushCommand) Execute(command *redisRequest, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
 	values := make([][]byte, 0)
 	key := command.Get(1)
 	for i := 2; i < command.ArgCount(); i++ {
@@ -82,7 +81,7 @@ func (cmd *lpushCommand) Execute(command *redisproto.Command, redis *PgRedis, tx
 
 type lrangeCommand struct{}
 
-func (cmd *lrangeCommand) Execute(command *redisproto.Command, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
+func (cmd *lrangeCommand) Execute(command *redisRequest, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
 	key := command.Get(1)
 	start, _ := strconv.Atoi(string(command.Get(2)))
 	end, _ := strconv.Atoi(string(command.Get(3)))
@@ -96,7 +95,7 @@ func (cmd *lrangeCommand) Execute(command *redisproto.Command, redis *PgRedis, t
 
 type lremCommand struct{}
 
-func (cmd *lremCommand) Execute(command *redisproto.Command, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
+func (cmd *lremCommand) Execute(command *redisRequest, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
 	key := command.Get(1)
 	count, _ := strconv.Atoi(string(command.Get(2)))
 	value := command.Get(3)
@@ -109,7 +108,7 @@ func (cmd *lremCommand) Execute(command *redisproto.Command, redis *PgRedis, tx 
 
 type rpopCommand struct{}
 
-func (cmd *rpopCommand) Execute(command *redisproto.Command, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
+func (cmd *rpopCommand) Execute(command *redisRequest, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
 	key := command.Get(1)
 	success, value, err := redis.lists.RightPop(tx, key)
 	if err != nil {
@@ -124,7 +123,7 @@ func (cmd *rpopCommand) Execute(command *redisproto.Command, redis *PgRedis, tx 
 
 type rpushCommand struct{}
 
-func (cmd *rpushCommand) Execute(command *redisproto.Command, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
+func (cmd *rpushCommand) Execute(command *redisRequest, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
 	values := make([][]byte, 0)
 	key := command.Get(1)
 	for i := 2; i < command.ArgCount(); i++ {

--- a/cmd_server.go
+++ b/cmd_server.go
@@ -4,13 +4,12 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"github.com/secmask/go-redisproto"
 	"strings"
 )
 
 type flushallCommand struct{}
 
-func (cmd *flushallCommand) Execute(command *redisproto.Command, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
+func (cmd *flushallCommand) Execute(command *redisRequest, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
 	err := redis.keys.FlushAll(tx)
 	if err != nil {
 		return nil, err
@@ -20,7 +19,7 @@ func (cmd *flushallCommand) Execute(command *redisproto.Command, redis *PgRedis,
 
 type clientCommand struct{}
 
-func (cmd *clientCommand) Execute(command *redisproto.Command, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
+func (cmd *clientCommand) Execute(command *redisRequest, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
 	subcommand := strings.ToUpper(string(command.Get(1)))
 	if subcommand == "SETNAME" {
 		return newPgRedisString("OK"), nil
@@ -31,7 +30,7 @@ func (cmd *clientCommand) Execute(command *redisproto.Command, redis *PgRedis, t
 
 type dbsizeCommand struct{}
 
-func (cmd *dbsizeCommand) Execute(command *redisproto.Command, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
+func (cmd *dbsizeCommand) Execute(command *redisRequest, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
 	count, err := redis.keys.Count(tx)
 	if err != nil {
 		return nil, err
@@ -41,7 +40,7 @@ func (cmd *dbsizeCommand) Execute(command *redisproto.Command, redis *PgRedis, t
 
 type infoCommand struct{}
 
-func (cmd *infoCommand) Execute(command *redisproto.Command, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
+func (cmd *infoCommand) Execute(command *redisRequest, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
 	result := make([]string, 0)
 	result = append(result, "# Server")
 	result = append(result, "redis_version:5.0.5")

--- a/cmd_sets.go
+++ b/cmd_sets.go
@@ -2,13 +2,11 @@ package pgredis
 
 import (
 	"database/sql"
-
-	"github.com/secmask/go-redisproto"
 )
 
 type saddCommand struct{}
 
-func (cmd *saddCommand) Execute(command *redisproto.Command, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
+func (cmd *saddCommand) Execute(command *redisRequest, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
 	key := command.Get(1)
 	values := make([][]byte, 0)
 	for i := 2; i < command.ArgCount(); i++ {
@@ -24,7 +22,7 @@ func (cmd *saddCommand) Execute(command *redisproto.Command, redis *PgRedis, tx 
 
 type scardCommand struct{}
 
-func (cmd *scardCommand) Execute(command *redisproto.Command, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
+func (cmd *scardCommand) Execute(command *redisRequest, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
 	key := command.Get(1)
 
 	count, err := redis.sets.Cardinality(tx, key)
@@ -36,7 +34,7 @@ func (cmd *scardCommand) Execute(command *redisproto.Command, redis *PgRedis, tx
 
 type sremCommand struct{}
 
-func (cmd *sremCommand) Execute(command *redisproto.Command, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
+func (cmd *sremCommand) Execute(command *redisRequest, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
 	key := command.Get(1)
 	values := make([][]byte, 0)
 	for i := 2; i < command.ArgCount(); i++ {
@@ -52,7 +50,7 @@ func (cmd *sremCommand) Execute(command *redisproto.Command, redis *PgRedis, tx 
 
 type smembersCommand struct{}
 
-func (cmd *smembersCommand) Execute(command *redisproto.Command, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
+func (cmd *smembersCommand) Execute(command *redisRequest, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
 	key := command.Get(1)
 
 	values, err := redis.sets.Members(tx, key)
@@ -64,7 +62,7 @@ func (cmd *smembersCommand) Execute(command *redisproto.Command, redis *PgRedis,
 
 type sscanCommand struct{}
 
-func (cmd *sscanCommand) Execute(command *redisproto.Command, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
+func (cmd *sscanCommand) Execute(command *redisRequest, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
 	key := command.Get(1)
 
 	values, err := redis.sets.Members(tx, key)

--- a/cmd_strings.go
+++ b/cmd_strings.go
@@ -7,12 +7,11 @@ import (
 	"strconv"
 
 	"github.com/32bitkid/bitreader"
-	"github.com/secmask/go-redisproto"
 )
 
 type appendCommand struct{}
 
-func (cmd *appendCommand) Execute(command *redisproto.Command, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
+func (cmd *appendCommand) Execute(command *redisRequest, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
 	key := command.Get(1)
 	value := command.Get(2)
 	newValue, err := redis.strings.InsertOrAppend(tx, key, value)
@@ -36,7 +35,7 @@ func intOrZero(value string) int {
 	}
 }
 
-func (cmd *bitcountCommand) Execute(command *redisproto.Command, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
+func (cmd *bitcountCommand) Execute(command *redisRequest, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
 	key := command.Get(1)
 	success, result, err := redis.strings.Get(tx, key)
 
@@ -93,7 +92,7 @@ func (cmd *bitcountCommand) Execute(command *redisproto.Command, redis *PgRedis,
 
 type decrCommand struct{}
 
-func (cmd *decrCommand) Execute(command *redisproto.Command, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
+func (cmd *decrCommand) Execute(command *redisRequest, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
 	key := command.Get(1)
 	newValue, err := redis.strings.Incr(tx, key, -1)
 	if err != nil {
@@ -105,7 +104,7 @@ func (cmd *decrCommand) Execute(command *redisproto.Command, redis *PgRedis, tx 
 
 type decrbyCommand struct{}
 
-func (cmd *decrbyCommand) Execute(command *redisproto.Command, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
+func (cmd *decrbyCommand) Execute(command *redisRequest, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
 	key := command.Get(1)
 	by, _ := strconv.Atoi(string(command.Get(2)))
 	newValue, err := redis.strings.Incr(tx, key, by*-1)
@@ -118,7 +117,7 @@ func (cmd *decrbyCommand) Execute(command *redisproto.Command, redis *PgRedis, t
 
 type getCommand struct{}
 
-func (cmd *getCommand) Execute(command *redisproto.Command, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
+func (cmd *getCommand) Execute(command *redisRequest, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
 	success, resp, err := redis.strings.Get(tx, command.Get(1))
 	if err != nil {
 		return nil, err
@@ -132,7 +131,7 @@ func (cmd *getCommand) Execute(command *redisproto.Command, redis *PgRedis, tx *
 
 type getbitCommand struct{}
 
-func (cmd *getbitCommand) Execute(command *redisproto.Command, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
+func (cmd *getbitCommand) Execute(command *redisRequest, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
 	success, resp, err := redis.strings.Get(tx, command.Get(1))
 	bitPosition, _ := strconv.Atoi(string(command.Get(2)))
 
@@ -161,7 +160,7 @@ func (cmd *getbitCommand) Execute(command *redisproto.Command, redis *PgRedis, t
 
 type getsetCommand struct{}
 
-func (cmd *getsetCommand) Execute(command *redisproto.Command, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
+func (cmd *getsetCommand) Execute(command *redisRequest, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
 	expiry_millis := 0
 	getSuccess, resp, err := redis.strings.Get(tx, command.Get(1))
 
@@ -182,7 +181,7 @@ func (cmd *getsetCommand) Execute(command *redisproto.Command, redis *PgRedis, t
 
 type getrangeCommand struct{}
 
-func (cmd *getrangeCommand) Execute(command *redisproto.Command, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
+func (cmd *getrangeCommand) Execute(command *redisRequest, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
 	success, result, err := redis.strings.Get(tx, command.Get(1))
 	if err != nil {
 		return nil, err
@@ -221,7 +220,7 @@ func (cmd *getrangeCommand) Execute(command *redisproto.Command, redis *PgRedis,
 
 type incrCommand struct{}
 
-func (cmd *incrCommand) Execute(command *redisproto.Command, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
+func (cmd *incrCommand) Execute(command *redisRequest, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
 	key := command.Get(1)
 	newValue, err := redis.strings.Incr(tx, key, 1)
 	if err != nil {
@@ -233,7 +232,7 @@ func (cmd *incrCommand) Execute(command *redisproto.Command, redis *PgRedis, tx 
 
 type incrbyCommand struct{}
 
-func (cmd *incrbyCommand) Execute(command *redisproto.Command, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
+func (cmd *incrbyCommand) Execute(command *redisRequest, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
 	key := command.Get(1)
 	by, _ := strconv.Atoi(string(command.Get(2)))
 	newValue, err := redis.strings.Incr(tx, key, by)
@@ -246,7 +245,7 @@ func (cmd *incrbyCommand) Execute(command *redisproto.Command, redis *PgRedis, t
 
 type incrbyfloatCommand struct{}
 
-func (cmd *incrbyfloatCommand) Execute(command *redisproto.Command, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
+func (cmd *incrbyfloatCommand) Execute(command *redisRequest, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
 	key := command.Get(1)
 	by, _ := strconv.ParseFloat(string(command.Get(2)), 64)
 	newValue, err := redis.strings.IncrDecimal(tx, key, by)
@@ -258,7 +257,7 @@ func (cmd *incrbyfloatCommand) Execute(command *redisproto.Command, redis *PgRed
 
 type mgetCommand struct{}
 
-func (cmd *mgetCommand) Execute(command *redisproto.Command, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
+func (cmd *mgetCommand) Execute(command *redisRequest, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
 	result := make([]pgRedisValue, command.ArgCount()-1)
 	for i := 1; i < command.ArgCount(); i++ {
 		// TODO calling getStrings in a loop like this returns the correct result, but is super
@@ -275,7 +274,7 @@ func (cmd *mgetCommand) Execute(command *redisproto.Command, redis *PgRedis, tx 
 
 type msetCommand struct{}
 
-func (cmd *msetCommand) Execute(command *redisproto.Command, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
+func (cmd *msetCommand) Execute(command *redisRequest, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
 	// TODO Using string because I can't use byte slices as a map key, but this probably breaks
 	// some compatibility with redis
 	items := make(map[string]string)
@@ -291,7 +290,7 @@ func (cmd *msetCommand) Execute(command *redisproto.Command, redis *PgRedis, tx 
 
 type setCommand struct{}
 
-func (cmd *setCommand) Execute(command *redisproto.Command, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
+func (cmd *setCommand) Execute(command *redisRequest, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
 	expiry_millis := 0
 	exValue := commandExValueInMillis(command)
 	if exValue > 0 {
@@ -335,7 +334,7 @@ func (cmd *setCommand) Execute(command *redisproto.Command, redis *PgRedis, tx *
 
 type setexCommand struct{}
 
-func (cmd *setexCommand) Execute(command *redisproto.Command, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
+func (cmd *setexCommand) Execute(command *redisRequest, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
 	key := command.Get(1)
 	expiry_secs, _ := strconv.Atoi(string(command.Get(2)))
 	value := command.Get(3)
@@ -350,7 +349,7 @@ func (cmd *setexCommand) Execute(command *redisproto.Command, redis *PgRedis, tx
 
 type psetexCommand struct{}
 
-func (cmd *psetexCommand) Execute(command *redisproto.Command, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
+func (cmd *psetexCommand) Execute(command *redisRequest, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
 	key := command.Get(1)
 	expiry_millis, _ := strconv.Atoi(string(command.Get(2)))
 	value := command.Get(3)
@@ -363,7 +362,7 @@ func (cmd *psetexCommand) Execute(command *redisproto.Command, redis *PgRedis, t
 
 type setnxCommand struct{}
 
-func (cmd *setnxCommand) Execute(command *redisproto.Command, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
+func (cmd *setnxCommand) Execute(command *redisRequest, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
 	key := command.Get(1)
 	value := command.Get(2)
 	expiry_millis := 0
@@ -381,7 +380,7 @@ func (cmd *setnxCommand) Execute(command *redisproto.Command, redis *PgRedis, tx
 
 type strlenCommand struct{}
 
-func (cmd *strlenCommand) Execute(command *redisproto.Command, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
+func (cmd *strlenCommand) Execute(command *redisRequest, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
 	success, resp, err := redis.strings.Get(tx, command.Get(1))
 	if err != nil {
 		return nil, err
@@ -393,7 +392,7 @@ func (cmd *strlenCommand) Execute(command *redisproto.Command, redis *PgRedis, t
 	}
 }
 
-func commandExValueInMillis(command *redisproto.Command) int {
+func commandExValueInMillis(command *redisRequest) int {
 	indexOfEx := indexOfValue(command, "EX")
 	if indexOfEx == 0 {
 		return 0
@@ -407,7 +406,7 @@ func commandExValueInMillis(command *redisproto.Command) int {
 	}
 }
 
-func commandPxValueInMillis(command *redisproto.Command) int {
+func commandPxValueInMillis(command *redisRequest) int {
 	indexOfPx := indexOfValue(command, "PX")
 	if indexOfPx == 0 {
 		return 0
@@ -421,7 +420,7 @@ func commandPxValueInMillis(command *redisproto.Command) int {
 	}
 }
 
-func indexOfValue(command *redisproto.Command, value string) int {
+func indexOfValue(command *redisRequest, value string) int {
 	for i := 1; i < command.ArgCount(); i++ {
 		if string(command.Get(i)) == value {
 			return i
@@ -430,7 +429,7 @@ func indexOfValue(command *redisproto.Command, value string) int {
 	return 0
 }
 
-func commandHasValue(command *redisproto.Command, value string) bool {
+func commandHasValue(command *redisRequest, value string) bool {
 	for i := 1; i < command.ArgCount(); i++ {
 		if string(command.Get(i)) == value {
 			return true

--- a/cmd_zsets.go
+++ b/cmd_zsets.go
@@ -5,13 +5,11 @@ import (
 	"errors"
 	"strconv"
 	"strings"
-
-	"github.com/secmask/go-redisproto"
 )
 
 type zaddCommand struct{}
 
-func (cmd *zaddCommand) Execute(command *redisproto.Command, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
+func (cmd *zaddCommand) Execute(command *redisRequest, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
 	xxArgProvided := false
 	nxArgProvided := false
 	chArgProvided := false
@@ -57,7 +55,7 @@ func (cmd *zaddCommand) Execute(command *redisproto.Command, redis *PgRedis, tx 
 
 type zcardCommand struct{}
 
-func (cmd *zcardCommand) Execute(command *redisproto.Command, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
+func (cmd *zcardCommand) Execute(command *redisRequest, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
 	key := command.Get(1)
 
 	count, err := redis.sortedsets.Cardinality(tx, key)
@@ -69,7 +67,7 @@ func (cmd *zcardCommand) Execute(command *redisproto.Command, redis *PgRedis, tx
 
 type zrangeCommand struct{}
 
-func (cmd *zrangeCommand) Execute(command *redisproto.Command, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
+func (cmd *zrangeCommand) Execute(command *redisRequest, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
 	key := command.Get(1)
 	start, _ := strconv.Atoi(string(command.Get(2)))
 	end, _ := strconv.Atoi(string(command.Get(3)))
@@ -84,7 +82,7 @@ func (cmd *zrangeCommand) Execute(command *redisproto.Command, redis *PgRedis, t
 
 type zrangebyscoreCommand struct{}
 
-func (cmd *zrangebyscoreCommand) Execute(command *redisproto.Command, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
+func (cmd *zrangebyscoreCommand) Execute(command *redisRequest, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
 	var min float64
 	var max float64
 	var minExclusive bool
@@ -125,7 +123,7 @@ func (cmd *zrangebyscoreCommand) Execute(command *redisproto.Command, redis *PgR
 
 type zremCommand struct{}
 
-func (cmd *zremCommand) Execute(command *redisproto.Command, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
+func (cmd *zremCommand) Execute(command *redisRequest, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
 	key := command.Get(1)
 	values := make([][]byte, 0)
 	for i := 2; i < command.ArgCount(); i++ {
@@ -142,7 +140,7 @@ func (cmd *zremCommand) Execute(command *redisproto.Command, redis *PgRedis, tx 
 
 type zremrangebyrankCommand struct{}
 
-func (cmd *zremrangebyrankCommand) Execute(command *redisproto.Command, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
+func (cmd *zremrangebyrankCommand) Execute(command *redisRequest, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
 	key := command.Get(1)
 	start, _ := strconv.Atoi(string(command.Get(2)))
 	end, _ := strconv.Atoi(string(command.Get(3)))
@@ -157,7 +155,7 @@ func (cmd *zremrangebyrankCommand) Execute(command *redisproto.Command, redis *P
 
 type zremrangebyscoreCommand struct{}
 
-func (cmd *zremrangebyscoreCommand) Execute(command *redisproto.Command, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
+func (cmd *zremrangebyscoreCommand) Execute(command *redisRequest, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
 	var min float64
 	var max float64
 	var minExclusive bool
@@ -193,7 +191,7 @@ func (cmd *zremrangebyscoreCommand) Execute(command *redisproto.Command, redis *
 
 type zrevrangeCommand struct{}
 
-func (cmd *zrevrangeCommand) Execute(command *redisproto.Command, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
+func (cmd *zrevrangeCommand) Execute(command *redisRequest, redis *PgRedis, tx *sql.Tx) (pgRedisValue, error) {
 	key := command.Get(1)
 	start, _ := strconv.Atoi(string(command.Get(2)))
 	end, _ := strconv.Atoi(string(command.Get(3)))
@@ -206,7 +204,7 @@ func (cmd *zrevrangeCommand) Execute(command *redisproto.Command, redis *PgRedis
 	return newPgRedisArrayOfStrings(items), nil
 }
 
-func commandLimitOffsetAndCount(command *redisproto.Command) (int, int) {
+func commandLimitOffsetAndCount(command *redisRequest) (int, int) {
 	indexOfLimit := indexOfValue(command, "LIMIT")
 	if indexOfLimit == 0 {
 		return 0, 0

--- a/redis_request.go
+++ b/redis_request.go
@@ -1,0 +1,63 @@
+package pgredis
+
+import (
+	"strings"
+
+	"github.com/secmask/go-redisproto"
+)
+
+// We parse incomintg requests using the redisproto lib, which hands them to us as redisproto.Cmd
+// structs. However, the properties of redisproto.Cmd aren't exported and the argv byte slice is
+// reused for subsequent requests from the client, so they're not safe to keep in a queue.
+//
+// This type exists so we can copy redisproto.Cmd into our our struct and keep a queue in memory.
+type redisRequest struct {
+	argv [][]byte
+	last bool
+}
+
+// Copy a redisproto.Cmd struct into a redisRequest
+func newRequestFromRedisProto(from *redisproto.Command) redisRequest {
+	last := from.IsLast()
+	argv := make([][]byte, 0, 2)
+	for i := 0; i < 100; i++ {
+		next := from.Get(i)
+		if next == nil {
+			break
+		}
+		nextCopy := make([]byte, len(next))
+		copy(nextCopy, next)
+		argv = append(argv, nextCopy)
+	}
+
+	return redisRequest{argv: argv, last: last}
+}
+
+// Return the first argument of the request as a string. This is typically the redis command (GET,
+// SET, etc)
+func (c *redisRequest) CommandString() string {
+	return strings.ToUpper(string(c.Get(0)))
+}
+
+// Fetch a space delimited part of the incoming request as a byte array. Exists for compatibility
+// with redisproto.Cmd, and we may not keep it around forever.
+func (c *redisRequest) Get(index int) []byte {
+	if index >= 0 && index < len(c.argv) {
+		return c.argv[index]
+	} else {
+		return nil
+	}
+}
+
+// Return the number of arguments in the request. Exists for compatibility  with redisproto.Cmd,
+// and we may not keep it around forever.
+func (c *redisRequest) ArgCount() int {
+	return len(c.argv)
+}
+
+// IsLast is true if this command is the last one in receive buffer, command handler should call writer.Flush()
+// after write response, helpful in process pipeline command. Exists for compatibility  with redisproto.Cmd,
+// and we may not keep it around forever.
+func (c *redisRequest) IsLast() bool {
+	return c.last
+}


### PR DESCRIPTION
This was originally implemented as a hacked together state machine, built as I got the MULTI specs green. I successfully got to a passing build, but always wanted to refactor it into something more readable.

Here's my first attempt at that. I've dropped the state machine and gone with an in-memory request queue instead. After each request is added to the queue, we examine the queue state and determine if any action is required.

I'm not totally happy with the result, but it's better than what I had so I'm going to merge it.

This approach has a bonus side effect: delaying the DB transaction until a `MULTI` is ready to `EXEC` means that we will have the option to select **all** keys that will be modified in the DB transaction and lock them in alphabetical order to avoid deadlocks. I'll make the locking change in a follow up commit or PR.

No specs were changed, and the suite is still green.

Closes #44